### PR TITLE
Add TypeScript declarations file. Allow default import in TypeScript

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,46 @@
+export default class EventBus{
+  /**
+  * Attach a callback to an event
+  * @param {string} eventName - name of the event.
+  * @param {function} callback - callback executed when this event is triggered
+  */
+  on(eventName: string, callback: () => void): void
+  /**
+   * Attach a callback to an event. This callback will not be executed more than once if the event is trigger mutiple times
+   * @param {string} eventName - name of the event.
+   * @param {function} callback - callback executed when this event is triggered
+   */
+  once(eventName: string, callback: () => void): void
+  /**
+  * Attach a callback to an event. This callback will be executed will not be executed more than the number if the event is trigger mutiple times
+  * @param {number} number - max number of executions
+  * @param {string} eventName - name of the event.
+  * @param {function} callback - callback executed when this event is triggered
+  */
+  exactly(number: number, eventName: string, callback: () => void): void
+  /**
+   * Kill an event with all it's callbacks
+   * @param {string} eventName - name of the event.
+   */
+  die(eventName: string): void
+  /**
+   * Kill an event with all it's callbacks
+   * @param {string} eventName - name of the event.
+   */
+  off(eventName: string): void
+  /**
+  * Remove the callback for the given event
+  * @param {string} eventName - name of the event.
+  * @param {callback} callback - the callback to remove (undefined to remove all of them).
+  */
+  detach(eventName: string, callback?: () => void): boolean
+  /**
+  * Remove all the events
+  */
+  detachAll(): void
+  /**
+   * Emit the event
+   * @param {string} eventName - name of the event.
+   */
+  emit(eventName: string): void
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,23 +1,24 @@
+declare type EventCallback = (...args: any[]) => void;
 export default class EventBus{
   /**
   * Attach a callback to an event
   * @param {string} eventName - name of the event.
   * @param {function} callback - callback executed when this event is triggered
   */
-  on(eventName: string, callback: () => void): void
+  on(eventName: string, callback: EventCallback): void
   /**
    * Attach a callback to an event. This callback will not be executed more than once if the event is trigger mutiple times
    * @param {string} eventName - name of the event.
    * @param {function} callback - callback executed when this event is triggered
    */
-  once(eventName: string, callback: () => void): void
+  once(eventName: string, callback: EventCallback): void
   /**
   * Attach a callback to an event. This callback will be executed will not be executed more than the number if the event is trigger mutiple times
   * @param {number} number - max number of executions
   * @param {string} eventName - name of the event.
   * @param {function} callback - callback executed when this event is triggered
   */
-  exactly(number: number, eventName: string, callback: () => void): void
+  exactly(number: number, eventName: string, callback: EventCallback): void
   /**
    * Kill an event with all it's callbacks
    * @param {string} eventName - name of the event.
@@ -33,7 +34,7 @@ export default class EventBus{
   * @param {string} eventName - name of the event.
   * @param {callback} callback - the callback to remove (undefined to remove all of them).
   */
-  detach(eventName: string, callback?: () => void): boolean
+  detach(eventName: string, callback?: EventCallback): boolean
   /**
   * Remove all the events
   */
@@ -42,5 +43,5 @@ export default class EventBus{
    * Emit the event
    * @param {string} eventName - name of the event.
    */
-  emit(eventName: string): void
+  emit<C = null>(eventName: string, context?: C, ...args: any[]): void
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 (function(caller, bus) {
   if (typeof exports === 'object' && typeof module === 'object') {
     module.exports = bus();
+    module.exports.default = module.exports;
   } else if (typeof exports === 'object') {
     exports.EventBus = bus();
   } else {


### PR DESCRIPTION
Added a type declaration file and default export.

This now works in TypeScript;
```typescript
import EventBus from 'js-event-bus';
const eventBus = new EventBus();
```